### PR TITLE
Change language "gitignore" to "ignore"

### DIFF
--- a/packages/dot-template-vscode/package.json
+++ b/packages/dot-template-vscode/package.json
@@ -215,7 +215,7 @@
       },
       {
         "path": "./res/snippets/inject-hash.json",
-        "language": "gitignore"
+        "language": "ignore"
       },
       {
         "path": "./res/snippets/inject-hash.json",


### PR DESCRIPTION
Now VS Code Insider complaints about invalid language, it seems that "gitignore" is actually not a valid built-in language in VS Code (even in stable release).

```
[qiu8310.dot-template-vscode]: Unknown language in `contributes.dot-template-vscode.language`. Provided value: gitignore
```